### PR TITLE
Pin versions in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas
-openpyxl
-streamlit
-tabula-py
+pandas==2.2.1
+openpyxl==3.1.2
+streamlit==1.32.2
+tabula-py==2.9.0


### PR DESCRIPTION
## Summary
- specify exact versions for key packages

## Testing
- `python -m py_compile streamlit_app.py update_inventory.py`
- `python - <<'EOF'
import pandas, openpyxl, streamlit, tabula
print(pandas.__version__, openpyxl.__version__, streamlit.__version__, tabula.__version__)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68406f803fe083319218ddb353ab7c12