### PR TITLE
Fix missing residual percentage parameter

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -169,6 +169,7 @@ if vin_input and county != "Select County":
             result = calculate_lease_payment(
                 selling_price=selling_price,
                 lease_cash=lease_cash,
+                residual_percentage=float(lease["Residual_Percentage"]),
                 residual_value_range=lease["Residual_Value"],
                 lease_term=lease["Lease_Term"],
                 credit_tier=credit_tier,


### PR DESCRIPTION
## Summary
- pass residual percentage into `calculate_lease_payment`

## Testing
- `python -m py_compile streamlit_app.py`
- `python - <<'EOF'
import streamlit_app as app
res = app.calculate_lease_payment(selling_price=30000, lease_cash=500, residual_percentage=0.6, residual_value_range='0.0025', lease_term=36, credit_tier='1 (740-999)', down_payment=1000, tax_rate=0.07)
print(res)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684071f6f8088331ba22ad2e1cbdfbcf