### PR TITLE
Fix style issues and improve lease filtering

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import os
 
+
 # Function to load CSV files with error handling
 @st.cache_data
 def load_data(file_path):
@@ -11,7 +12,22 @@ def load_data(file_path):
     return pd.read_csv(file_path)
 
 # Lease payment calculation function
-def calculate_lease_payment(selling_price, lease_cash, residual_percentage, residual_value_range, lease_term, credit_tier, down_payment, tax_rate, acquisition_fee=650, money_factor_markup=0.0004, apply_markup=True, apply_lease_cash=True):
+
+
+def calculate_lease_payment(
+    selling_price,
+    lease_cash,
+    residual_percentage,
+    residual_value_range,
+    lease_term,
+    credit_tier,
+    down_payment,
+    tax_rate,
+    acquisition_fee=650,
+    money_factor_markup=0.0004,
+    apply_markup=True,
+    apply_lease_cash=True,
+):
     # Parse residual value (money factor) range
     if residual_value_range and isinstance(residual_value_range, str):
         if "-" in residual_value_range:
@@ -71,6 +87,7 @@ def calculate_lease_payment(selling_price, lease_cash, residual_percentage, resi
         "Due at Signing": round(due_at_signing, 2),
         "Available Lease Cash": f"${lease_cash}" if lease_cash > 0 else "None"
     }
+
 
 # Title of the app
 st.title("Hyundai Dealer Inventory and Lease Tool")
@@ -133,15 +150,14 @@ if vin_input and county != "Select County":
         st.write(f"**Model Number**: {vehicle['MODEL']}")
 
         # Find applicable lease programs
-        applicable_leases = lease_data[
-            (lease_data["Model_Year"] == vehicle["YEAR"]) &
-            (
-                lease_data["Model_Number"].str.contains(
-                    vehicle["MODEL"].split("F")[0]
-                )
-            ) &
-            (lease_data["Trim"].str.lower() == vehicle["TRIM"].split()[0].lower())
-        ]
+        model_year_match = lease_data["Model_Year"] == vehicle["YEAR"]
+        model_number_match = lease_data["Model_Number"].str.contains(
+            vehicle["MODEL"].split("F")[0]
+        )
+        trim_match = (
+            lease_data["Trim"].str.lower() == vehicle["TRIM"].split()[0].lower()
+        )
+        applicable_leases = lease_data[model_year_match & model_number_match & trim_match]
 
         if applicable_leases.empty:
             st.warning("No lease programs found for this vehicle. Using default assumptions.")

--- a/update_inventory.py
+++ b/update_inventory.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import os
 
+
 def update_inventory(excel_path, output_csv_path):
     # Check if the Excel file exists
     if not os.path.exists(excel_path):
@@ -30,5 +31,9 @@ def update_inventory(excel_path, output_csv_path):
     df.to_csv(output_csv_path, index=False)
     print(f"✅ Inventory updated and saved as {output_csv_path}")
 
+
 if __name__ == "__main__":
-    update_inventory("Inventory_Detail_20250527.xlsx", "Drivepath_Dealer_Inventory.csv")
+    update_inventory(
+        "Inventory_Detail_20250527.xlsx",
+        "Drivepath_Dealer_Inventory.csv",
+    )


### PR DESCRIPTION
## Summary
- address flake8 warnings by adding blank lines and reformatting functions
- refactor lease filtering logic for clarity
- ensure update script style complies with flake8

## Testing
- `flake8 --ignore=E501`
- `python -m py_compile streamlit_app.py update_inventory.py`
- `python update_inventory.py`
- `streamlit run streamlit_app.py` *(launched briefly to check for startup errors)*

------
https://chatgpt.com/codex/tasks/task_e_684075e7736c8331af6dcdda5b20999f