### PR TITLE
Add lease options expander

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -158,8 +158,17 @@ if vin_input and county != "Select County":
         down_payment = st.number_input("Down Payment ($)", min_value=0.0, value=0.0, step=100.0)
         tax_rate = tax_rates.get(county, 0.0725)
 
-        apply_markup = st.toggle("Apply 0.0004 Money Factor Markup", value=True)
-        apply_lease_cash = st.toggle("Apply Lease Cash Discount", value=False)
+        with st.expander("Lease Options"):
+            apply_markup = st.toggle(
+                "Apply 0.0004 Money Factor Markup",
+                value=True,
+                key="apply_markup",
+            )
+            apply_lease_cash = st.toggle(
+                "Apply Lease Cash Discount",
+                value=False,
+                key="apply_lease_cash",
+            )
 
         lease_results = []
         for _, lease in applicable_leases.iterrows():


### PR DESCRIPTION
## Summary
- wrap markup and lease cash toggles in an `st.expander`
- add unique keys for each toggle

## Testing
- `python3 -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68531b31980c8331afe6e80f53680e1c